### PR TITLE
Fix declaration of \Bex\Monolog\ExceptionHandlerLog::write according to the last bitrix version (16.5.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ The result in the Control Panel of Bitrix:
 ## Requirements
 
 * PHP >= 5.3
-* Bitrix CMS >= 15.0.2
+* Bitrix CMS >= 16.5.6

--- a/src/ExceptionHandlerLog.php
+++ b/src/ExceptionHandlerLog.php
@@ -96,7 +96,7 @@ class ExceptionHandlerLog extends \Bitrix\Main\Diag\ExceptionHandlerLog
     /**
      * {@inheritdoc}
      */
-    public function write(\Exception $exception, $logType)
+    public function write($exception, $logType)
     {
         foreach ($this->rules as $rule => $condition)
         {


### PR DESCRIPTION
В абстрактном классе \Bitrix\Main\Diag\ExceptionHandlerLog в методе write первый параметр прописан без тайпхинтинга. Когда именно это поменялось - не могу сказать ... но текущей последней стабильной версии битрикса, php будет ругаться на адаптер с сообщением:

Fatal error: Declaration of Bex\Monolog\ExceptionHandlerLog::write() must be compatible with Bitrix\Main\Diag\ExceptionHandlerLog::write($exception, $logType) in .../vendor/bitrix-expert/monolog-adapter/src/ExceptionHandlerLog.php on line 134
