### PR TITLE
logging to iblocks and show notify for admin

### DIFF
--- a/src/Agents/Iblock.php
+++ b/src/Agents/Iblock.php
@@ -1,0 +1,52 @@
+<?
+namespace Bex\Monolog\Agents;
+
+class Iblock
+{
+    /**
+     * Deleting all elements from iblock, except the first $countElements elements
+     * @param $countElements
+     * @param $iblockID
+     * @return string
+     */
+    public static function AgentDeleteOldElementsByCount($countElements, $iblockID)
+    {
+        if (\CModule::IncludeModule("iblock")) {
+            $arSelect = Array("ID");
+            $arFilter = Array("IBLOCK_ID" => $iblockID);
+            $rsResult = \CIBlockElement::GetList(Array("timestamp_x" => "DESC"), $arFilter, false, false, $arSelect);
+            $intCounter = 1;
+            while ($arItem = $rsResult->GetNext()) {
+                if ($intCounter > $countElements) {
+                    \CIBlockElement::Delete($arItem["ID"]);
+                }
+                $intCounter++;
+            }
+        }
+
+        return "\Bex\Monolog\Agents\Iblock::AgentDeleteOldElementsByCount(" . $countElements . ", " . $iblockID . ");";
+    }
+
+    /**
+     * Deleting elements from iblock, who are older than $countDays days
+     * @param $countDays
+     * @param $iblockID
+     * @return string
+     */
+    public static function AgentDeleteOldElementsByLastChangeTime($countDays, $iblockID)
+    {
+        if (\CModule::IncludeModule("iblock")) {
+            $arSelect = Array("ID");
+            $arFilter = Array(
+                "IBLOCK_ID" => $iblockID,
+                ">DATE_ACTIVE_FROM" => (new \DateTime())->modify('-' . $countDays . ' days')->format('d.m.Y')
+            );
+            $rsResult = \CIBlockElement::GetList(Array(), $arFilter, false, false, $arSelect);
+            while ($arItem = $rsResult->GetNext()) {
+                \CIBlockElement::Delete($arItem["ID"]);
+            }
+        }
+
+        return "\Bex\Monolog\Agents\Iblock::AgentDeleteOldElementsByLastChangeTime(" . $countDays . ", " . $iblockID . ");";
+    }
+}

--- a/src/Formatter/BitrixIblockFormatter.php
+++ b/src/Formatter/BitrixIblockFormatter.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Bex\Monolog\Formatter;
+
+use Bitrix\Main\Type\DateTime;
+
+/**
+ * Record formatter for iblock of Bitrix.
+ * 
+ * Context of record will also be written to iblock of Bitrix.
+ * 
+ * @author GSU <gsu1234@mail.ru>
+ */
+class BitrixIblockFormatter extends BitrixFormatter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function format(array $record)
+    {
+        $record['level'] = parent::toBitrixLevel($record['level']);
+
+        $objDateTime = new DateTime();
+        $record['title'] = $record["channel"] . ": ";
+        $record['title'] .= "[" . $record['level'] . "] ";
+        $record['title'] .= $record['message'];
+        $record['title'] .= " - " . $objDateTime->toString();
+
+        if (!empty($record['context']))
+        {
+            $arData = [];
+            foreach ($record['context'] as $field => $value) {
+                if (is_array($value)) {
+                    $value = var_export($value, true);
+                }
+                $arData[] = $field . "\n\n" . $value;
+            }
+            $record['data'] = implode("\n\n\n\n", $arData);
+        }
+
+        return $record;
+    }
+
+}

--- a/src/Handler/BitrixIblockHandler.php
+++ b/src/Handler/BitrixIblockHandler.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Bex\Monolog\Handler;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use Bex\Monolog\Formatter\BitrixIblockFormatter;
+use Bitrix\Main\Loader;
+/**
+ * Monolog handler for the iblock of Bitrix CMS.
+ * 
+ * @author GSU <gsu1234@mail.ru>
+ */
+class BitrixIblockHandler extends AbstractProcessingHandler
+{
+    private $iblockID;
+    private $notifyToAdmin;
+
+    /**
+     * BitrixIblockHandler constructor.
+     * @param int $iblock_id
+     * @param bool|int $level The minimum logging level at which this handler will be triggered.
+     * @param int $rotating_count_elements Deleting by agents all elements from iblock, except the first
+     * $rotating_count_elements elements. If $rotating_count_elements == 0, then the elements will not be deleted.
+     * @param int $rotating_count_days Deleting elements from iblock, who are older than $countDays days.
+     * @param bool $notify_to_admin
+     * @param bool $bubble Whether the messages that are handled can bubble up the stack or not.
+     */
+    public function __construct($iblock_id, $level = Logger::DEBUG, $rotating_count_elements = 0, $rotating_count_days = 0, $notify_to_admin = false, $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+        $this->setIblockID($iblock_id);
+        $this->setNotifyToAdmin($notify_to_admin);
+
+        if($rotating_count_elements > 0) {
+            $result = \CAgent::GetList(Array("ID" => "DESC"), array("NAME" => "\Bex\Monolog\Agents\Iblock::AgentDeleteOldElementsByCount(" . $rotating_count_elements . ", " . $iblock_id . ");"));
+            if(!$result->NavNext(true)){
+                \CAgent::AddAgent(
+                    "\Bex\Monolog\Agents\Iblock::AgentDeleteOldElementsByCount(" . $rotating_count_elements . ", " . $iblock_id . ");"
+                );
+            }
+        }
+
+        if($rotating_count_days > 0) {
+            $result = \CAgent::GetList(Array("ID" => "DESC"), array("NAME" => "\Bex\Monolog\Agents\Iblock::AgentDeleteOldElementsByLastChangeTime(" . $rotating_count_days . ", " . $iblock_id . ");"));
+            if(!$result->NavNext(true)){
+                \CAgent::AddAgent(
+                    "\Bex\Monolog\Agents\Iblock::AgentDeleteOldElementsByLastChangeTime(" . $rotating_count_days . ", " . $iblock_id . ");"
+                );
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        global $USER;
+        Loader::includeModule("iblock");
+        $el = new \CIBlockElement;
+        $arLoadElementArray = Array(
+            "MODIFIED_BY"    => $USER->GetID(),
+            "IBLOCK_SECTION_ID" => false,
+            "IBLOCK_ID"      => $this->getIblockID(),
+            "NAME"           => $record['formatted']['title'],
+            "ACTIVE"         => "Y",
+            "PREVIEW_TEXT"   => $record['formatted']['data']
+        );
+        $logRecordID = $el->Add($arLoadElementArray);
+
+        if($this->getNotifyToAdmin()) {
+            Loader::includeModule("main");
+            \CAdminNotify::Add(array(
+                    'MESSAGE' => $record['formatted']['title'],
+                    'TAG' => $record["channel"] . "_" . $logRecordID,
+                    'MODULE_ID' => '0',
+                    'ENABLE_CLOSE' => 'Y'
+                )
+            );
+
+        }
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new BitrixIblockFormatter();
+    }
+
+    /**
+     * @param $iblockID
+     */
+    public function setIblockID($iblockID){
+        $this->iblockID = $iblockID;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getIblockID(){
+        return $this->iblockID;
+    }
+
+    /**
+     * @param $notifyToAdmin
+     */
+    public function setNotifyToAdmin($notifyToAdmin){
+        $this->notifyToAdmin = $notifyToAdmin;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNotifyToAdmin(){
+        return $this->notifyToAdmin;
+    }
+
+
+}


### PR DESCRIPTION
Hi.
I added additional functionality to the monolog-adapter. 
Description new functional:
Logging to iblock
http://prntscr.com/jaf5d7
http://prntscr.com/jaf61f

Show log record in admin notify
http://prntscr.com/jaf8ot

Example monolog-adapter settings in .settings.php
`'monolog' => array(
        'value' => array(
            'formatters' => array(
                'StreamHandlerFormatter' => array(
                    'class' => '\Monolog\Formatter\LineFormatter',
                    "format" => "%datetime% > %level_name% > %message% %context% %extra%\n",
                    "dateFormat" => "Y n j, g:i a"
                )
            ),
            'handlers' => array(
                ...........
                'BitrixIblockHandler' => array(
                    'class' => '\Bex\Monolog\Handler\BitrixIblockHandler',
                    'level' => 'DEBUG',
                    'iblock_id' => 10, //iblock id in which logs will be recorded
                    'rotating_count_elements' => 5, //deleting all records from iblock, except the first 'rotating_count_elements' elements
                    'rotating_count_days' => 2, // deleting elements from iblock, who are older than  'rotating_count_days' days
                    'notify_to_admin' => true //show notifications for admin
                ),
            ),
            'loggers' => array(
                'app' => array(
                    'handlers' => array('default'),
                ),
                'debug' => array(
                    'handlers' => array('debug_log'),
                ),
                'loggerToFile' => array(
                    'handlers' => array('StreamHandler'),
                ),
                'loggerToFileFormatted' => array(
                    'handlers' => array('StreamHandlerFormatted'),
                ),
                'loggerToBrowserConsole' => array(
                    'handlers' => array('BrowserConsoleHandler'),
                ),
                'loggerToRotatingFile' => array(
                    'handlers' => array('RotatingFileHandler'),
                ),
                'loggerToNativeMailer' => array(
                    'handlers' => array('NativeMailerHandler'),
                ),
                'loggerToSlackWebhook' => array(
                    'handlers' => array('SlackWebhookHandler'),
                ),
                'loggerToAll' => array(
                    'handlers' => array('debug_log', 'StreamHandler', 'StreamHandlerFormatted', 'BrowserConsoleHandler',
                        'RotatingFileHandler', 'NativeMailerHandler', 'SlackWebhookHandler', 'BitrixIblockHandler'),
                ),

            )
        ),
        'readonly' => false
    ),`

Example usage:
`use Monolog\Logger;
$loggerToAll = \Monolog\Registry::getInstance('loggerToAll');

$loggerToAll->addWarning('test logs settings all');
$loggerToAll->warning('warning text example settings all');
$loggerToAll->error('error text example settings all');
$loggerToAll->error('error text settings all', array('session' => $_SESSION));
$loggerToAll->info('info text example settings all');
$loggerToAll->info('info text settings all', array('session' => $_SESSION));
$loggerToAll->debug('debug text settings all', array('session' => $_SESSION));
$loggerToAll->info(json_encode(array('session settings all' => $_SESSION)));
$loggerToAll->addInfo('new message settings all', array('session' => $_SESSION));
`